### PR TITLE
Add reference collection overlay

### DIFF
--- a/afrc/migrations/0001_initial.py
+++ b/afrc/migrations/0001_initial.py
@@ -1439,6 +1439,32 @@ class Migration(migrations.Migration):
                 },
                 "layers": [
                     {
+                        "id": "referencecollections-point-stroke",
+                        "source": "referencecollections",
+                        "source-layer": "referencecollections",
+                        "type": "circle",
+                        "filter": ['all',[
+                            "==", "$type", "Point"
+                        ]],
+                        "paint": {
+                            "circle-radius": 6,
+                            "circle-opacity": 1,
+                            "circle-color": "#00f"
+                        }
+                    }, {
+                        "id": "referencecollections-point",
+                        "source": "referencecollections",
+                        "source-layer": "referencecollections",
+                        "type": "circle",
+                        "filter": ['all',[
+                            "==", "$type", "Point"
+                        ]],
+                        "paint": {
+                            "circle-radius": 3,
+                            "circle-color": "#aaf"
+                        }
+                    },
+                    {
                         "id": "referencecollections-line",
                         "type": "line",
                         "paint": {

--- a/afrc/migrations/0001_initial.py
+++ b/afrc/migrations/0001_initial.py
@@ -1447,9 +1447,14 @@ class Migration(migrations.Migration):
                             "==", "$type", "Point"
                         ]],
                         "paint": {
-                            "circle-radius": 6,
+                            "circle-radius": [
+                                "case",
+                                ["boolean", ["feature-state", "selected"], False],
+                                6,
+                                4
+                            ],
                             "circle-opacity": 1,
-                            "circle-color": "#00f"
+                            "circle-color": "#00f",
                         }
                     }, {
                         "id": "referencecollections-point",
@@ -1469,7 +1474,12 @@ class Migration(migrations.Migration):
                         "type": "line",
                         "paint": {
                             "line-color": "#00f",
-                            "line-width": 3
+                            "line-width": [
+                                "case",
+                                ["boolean", ["feature-state", "selected"], False],
+                                3,
+                                1
+                            ]
                         },
                         "layout": {
                             "line-cap": "round",
@@ -1483,7 +1493,12 @@ class Migration(migrations.Migration):
                         "type": "line",
                         "paint": {
                             "line-color": "#00f",
-                            "line-width": 3
+                            "line-width": [
+                                "case",
+                                ["boolean", ["feature-state", "selected"], False],
+                                3,
+                                1
+                            ],
                         },
                         "filter": [
                             "==",
@@ -1503,7 +1518,7 @@ class Migration(migrations.Migration):
                         "paint": {
                             "fill-color": "#00f",
                             "fill-opacity": 0.1,
-                            "fill-outline-color": "#0ff"
+                            "fill-outline-color": "#00f"
                         },
                         "filter": [
                             "==",

--- a/afrc/migrations/0001_initial.py
+++ b/afrc/migrations/0001_initial.py
@@ -1,0 +1,1567 @@
+import uuid
+from django.db import migrations
+from django.utils.translation import gettext as _
+import json
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+    dependencies = [
+        ("models", "11499_add_editlog_resourceinstance_idx"),
+    ]
+
+    def add_map_layers(apps, schema_editor):
+        MapSource = apps.get_model("models", "MapSource")
+        MapLayer = apps.get_model("models", "MapLayer")
+
+        ofm_positron_light = {
+            "maplayerid": uuid.UUID("803829fe-b437-40b2-94a4-8ae10fa25b10"),
+            "sortorder": 0,
+            "style": {
+                "name": "Positron",
+                "sources": {
+                    "ne2_shaded": {
+                    "maxzoom": 6,
+                    "tileSize": 256,
+                    "tiles": [
+                        "https://tiles.openfreemap.org/natural_earth/ne2sr/{z}/{x}/{y}.png"
+                    ],
+                    "type": "raster"
+                    },
+                    "openmaptiles": {
+                    "type": "vector",
+                    "url": "https://tiles.openfreemap.org/planet"
+                    }
+                },
+                "layers": [
+                    {
+                    "id": "background",
+                    "type": "background",
+                    "layout": {"visibility": "visible"},
+                    "paint": {"background-color": "rgb(242,243,240)"}
+                    },
+                    {
+                    "id": "park",
+                    "type": "fill",
+                    "source": "openmaptiles",
+                    "source-layer": "park",
+                    "filter": ["==", ["geometry-type"], "Polygon"],
+                    "layout": {"visibility": "none"},
+                    "paint": {"fill-color": "rgb(230, 230, 230)"}
+                    },
+                    {
+                    "id": "water",
+                    "type": "fill",
+                    "source": "openmaptiles",
+                    "source-layer": "water",
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "Polygon"],
+                        ["!=", ["get", "brunnel"], "tunnel"]
+                    ],
+                    "layout": {"visibility": "visible"},
+                    "paint": {"fill-antialias": True, "fill-color": "rgb(220, 220, 220)"}
+                    },
+                    {
+                    "id": "landcover_ice_shelf",
+                    "type": "fill",
+                    "source": "openmaptiles",
+                    "source-layer": "landcover",
+                    "maxzoom": 8,
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "Polygon"],
+                        ["==", ["get", "subclass"], "ice_shelf"]
+                    ],
+                    "paint": {"fill-color": "hsl(0,0%,98%)", "fill-opacity": 0.7}
+                    },
+                    {
+                    "id": "landcover_glacier",
+                    "type": "fill",
+                    "source": "openmaptiles",
+                    "source-layer": "landcover",
+                    "maxzoom": 8,
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "Polygon"],
+                        ["==", ["get", "subclass"], "glacier"]
+                    ],
+                    "paint": {
+                        "fill-color": "hsl(0,0%,98%)",
+                        "fill-opacity": ["interpolate", ["linear"], ["zoom"], 0, 1, 8, 0.5]
+                    }
+                    },
+                    {
+                    "id": "landuse_residential",
+                    "type": "fill",
+                    "source": "openmaptiles",
+                    "source-layer": "landuse",
+                    "maxzoom": 16,
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "Polygon"],
+                        ["==", ["get", "class"], "residential"]
+                    ],
+                    "layout": {"visibility": "visible"},
+                    "paint": {
+                        "fill-color": "rgb(230, 230, 230)",
+                        "fill-opacity": [
+                        "interpolate",
+                        ["exponential", 0.6],
+                        ["zoom"],
+                        8,
+                        0.8,
+                        9,
+                        0.6
+                        ]
+                    }
+                    },
+                    {
+                    "id": "landcover_wood",
+                    "type": "fill",
+                    "source": "openmaptiles",
+                    "source-layer": "landcover",
+                    "minzoom": 10,
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "Polygon"],
+                        ["==", ["get", "class"], "wood"]
+                    ],
+                    "layout": {"visibility": "visible"},
+                    "paint": {
+                        "fill-color": "rgb(220,220,220)",
+                        "fill-opacity": ["interpolate", ["linear"], ["zoom"], 8, 0, 12, 1]
+                    }
+                    },
+                    {
+                    "id": "waterway",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "waterway",
+                    "filter": ["==", ["geometry-type"], "LineString"],
+                    "layout": {"visibility": "visible"},
+                    "paint": {"line-color": "hsl(195,17%,78%)"}
+                    },
+                    {
+                    "id": "building",
+                    "type": "fill",
+                    "source": "openmaptiles",
+                    "source-layer": "building",
+                    "minzoom": 12,
+                    "paint": {
+                        "fill-antialias": True,
+                        "fill-color": "rgb(234, 234, 229)",
+                        "fill-outline-color": "rgb(219, 219, 218)"
+                    }
+                    },
+                    {
+                    "id": "tunnel_motorway_casing",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation",
+                    "minzoom": 6,
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "LineString"],
+                        [
+                        "all",
+                        ["==", ["get", "brunnel"], "tunnel"],
+                        ["==", ["get", "class"], "motorway"]
+                        ]
+                    ],
+                    "layout": {"line-cap": "butt", "line-join": "miter"},
+                    "paint": {
+                        "line-color": "rgb(213, 213, 213)",
+                        "line-opacity": 1,
+                        "line-width": [
+                        "interpolate",
+                        ["exponential", 1.4],
+                        ["zoom"],
+                        5.8,
+                        0,
+                        6,
+                        3,
+                        20,
+                        40
+                        ]
+                    }
+                    },
+                    {
+                    "id": "tunnel_motorway_inner",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation",
+                    "minzoom": 6,
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "LineString"],
+                        [
+                        "all",
+                        ["==", ["get", "brunnel"], "tunnel"],
+                        ["==", ["get", "class"], "motorway"]
+                        ]
+                    ],
+                    "layout": {"line-cap": "round", "line-join": "round"},
+                    "paint": {
+                        "line-color": "rgb(234,234,234)",
+                        "line-width": [
+                        "interpolate",
+                        ["exponential", 1.4],
+                        ["zoom"],
+                        4,
+                        2,
+                        6,
+                        1.3,
+                        20,
+                        30
+                        ]
+                    }
+                    },
+                    {
+                    "id": "aeroway-taxiway",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "aeroway",
+                    "minzoom": 12,
+                    "filter": ["match", ["get", "class"], ["taxiway"], True, False],
+                    "layout": {"line-cap": "round", "line-join": "round"},
+                    "paint": {
+                        "line-color": "hsl(0,0%,88%)",
+                        "line-opacity": 1,
+                        "line-width": [
+                        "interpolate",
+                        ["exponential", 1.55],
+                        ["zoom"],
+                        13,
+                        1.8,
+                        20,
+                        20
+                        ]
+                    }
+                    },
+                    {
+                    "id": "aeroway-runway-casing",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "aeroway",
+                    "minzoom": 11,
+                    "filter": ["match", ["get", "class"], ["runway"], True, False],
+                    "layout": {"line-cap": "round", "line-join": "round"},
+                    "paint": {
+                        "line-color": "hsl(0,0%,88%)",
+                        "line-opacity": 1,
+                        "line-width": [
+                        "interpolate",
+                        ["exponential", 1.5],
+                        ["zoom"],
+                        11,
+                        6,
+                        17,
+                        55
+                        ]
+                    }
+                    },
+                    {
+                    "id": "aeroway-area",
+                    "type": "fill",
+                    "source": "openmaptiles",
+                    "source-layer": "aeroway",
+                    "minzoom": 4,
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "Polygon"],
+                        ["match", ["get", "class"], ["runway", "taxiway"], True, False]
+                    ],
+                    "paint": {
+                        "fill-color": "rgba(255, 255, 255, 1)",
+                        "fill-opacity": ["interpolate", ["linear"], ["zoom"], 13, 0, 14, 1]
+                    }
+                    },
+                    {
+                    "id": "aeroway-runway",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "aeroway",
+                    "minzoom": 11,
+                    "filter": [
+                        "all",
+                        ["match", ["get", "class"], ["runway"], True, False],
+                        ["==", ["geometry-type"], "LineString"]
+                    ],
+                    "layout": {"line-cap": "round", "line-join": "round"},
+                    "paint": {
+                        "line-color": "rgba(255, 255, 255, 1)",
+                        "line-opacity": 1,
+                        "line-width": [
+                        "interpolate",
+                        ["exponential", 1.5],
+                        ["zoom"],
+                        11,
+                        4,
+                        17,
+                        50
+                        ]
+                    }
+                    },
+                    {
+                    "id": "road_area_pier",
+                    "type": "fill",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation",
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "Polygon"],
+                        ["==", ["get", "class"], "pier"]
+                    ],
+                    "paint": {"fill-antialias": True, "fill-color": "rgb(242,243,240)"}
+                    },
+                    {
+                    "id": "road_pier",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation",
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "LineString"],
+                        ["match", ["get", "class"], ["pier"], True, False]
+                    ],
+                    "layout": {"line-cap": "round", "line-join": "round"},
+                    "paint": {
+                        "line-color": "rgb(242,243,240)",
+                        "line-width": [
+                        "interpolate",
+                        ["exponential", 1.2],
+                        ["zoom"],
+                        15,
+                        1,
+                        17,
+                        4
+                        ]
+                    }
+                    },
+                    {
+                    "id": "highway_path",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation",
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "LineString"],
+                        ["==", ["get", "class"], "path"]
+                    ],
+                    "layout": {"line-cap": "round", "line-join": "round"},
+                    "paint": {
+                        "line-color": "rgb(234, 234, 234)",
+                        "line-opacity": 0.9,
+                        "line-width": [
+                        "interpolate",
+                        ["exponential", 1.2],
+                        ["zoom"],
+                        13,
+                        1,
+                        20,
+                        10
+                        ]
+                    }
+                    },
+                    {
+                    "id": "highway_minor",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation",
+                    "minzoom": 8,
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "LineString"],
+                        ["match", ["get", "class"], ["minor", "service", "track"], True, False]
+                    ],
+                    "layout": {"line-cap": "round", "line-join": "round"},
+                    "paint": {
+                        "line-color": "hsl(0,0%,88%)",
+                        "line-opacity": 0.9,
+                        "line-width": [
+                        "interpolate",
+                        ["exponential", 1.55],
+                        ["zoom"],
+                        13,
+                        1.8,
+                        20,
+                        20
+                        ]
+                    }
+                    },
+                    {
+                    "id": "highway_major_casing",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation",
+                    "minzoom": 11,
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "LineString"],
+                        [
+                        "match",
+                        ["get", "class"],
+                        ["primary", "secondary", "tertiary", "trunk"],
+                        True,
+                        False
+                        ]
+                    ],
+                    "layout": {"line-cap": "butt", "line-join": "miter"},
+                    "paint": {
+                        "line-color": "rgb(213, 213, 213)",
+                        "line-dasharray": [12, 0],
+                        "line-width": [
+                        "interpolate",
+                        ["exponential", 1.3],
+                        ["zoom"],
+                        10,
+                        3,
+                        20,
+                        23
+                        ]
+                    }
+                    },
+                    {
+                    "id": "highway_major_inner",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation",
+                    "minzoom": 11,
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "LineString"],
+                        [
+                        "match",
+                        ["get", "class"],
+                        ["primary", "secondary", "tertiary", "trunk"],
+                        True,
+                        False
+                        ]
+                    ],
+                    "layout": {"line-cap": "round", "line-join": "round"},
+                    "paint": {
+                        "line-color": "#fff",
+                        "line-width": [
+                        "interpolate",
+                        ["exponential", 1.3],
+                        ["zoom"],
+                        10,
+                        2,
+                        20,
+                        20
+                        ]
+                    }
+                    },
+                    {
+                    "id": "highway_major_subtle",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation",
+                    "maxzoom": 11,
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "LineString"],
+                        [
+                        "match",
+                        ["get", "class"],
+                        ["primary", "secondary", "tertiary", "trunk"],
+                        True,
+                        False
+                        ]
+                    ],
+                    "layout": {"line-cap": "round", "line-join": "round"},
+                    "paint": {"line-color": "hsla(0,0%,85%,0.69)", "line-width": 2}
+                    },
+                    {
+                    "id": "highway_motorway_casing",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation",
+                    "minzoom": 6,
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "LineString"],
+                        [
+                        "all",
+                        ["match", ["get", "brunnel"], ["bridge", "tunnel"], False, True],
+                        ["==", ["get", "class"], "motorway"]
+                        ]
+                    ],
+                    "layout": {"line-cap": "butt", "line-join": "miter"},
+                    "paint": {
+                        "line-color": "rgb(213, 213, 213)",
+                        "line-dasharray": [2, 0],
+                        "line-opacity": 1,
+                        "line-width": [
+                        "interpolate",
+                        ["exponential", 1.4],
+                        ["zoom"],
+                        5.8,
+                        0,
+                        6,
+                        3,
+                        20,
+                        40
+                        ]
+                    }
+                    },
+                    {
+                    "id": "highway_motorway_inner",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation",
+                    "minzoom": 6,
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "LineString"],
+                        [
+                        "all",
+                        ["match", ["get", "brunnel"], ["bridge", "tunnel"], False, True],
+                        ["==", ["get", "class"], "motorway"]
+                        ]
+                    ],
+                    "layout": {"line-cap": "round", "line-join": "round"},
+                    "paint": {
+                        "line-color": [
+                        "interpolate",
+                        ["linear"],
+                        ["zoom"],
+                        5.8,
+                        "hsla(0,0%,85%,0.53)",
+                        6,
+                        "#fff"
+                        ],
+                        "line-width": [
+                        "interpolate",
+                        ["exponential", 1.4],
+                        ["zoom"],
+                        4,
+                        2,
+                        6,
+                        1.3,
+                        20,
+                        30
+                        ]
+                    }
+                    },
+                    {
+                    "id": "highway_motorway_subtle",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation",
+                    "maxzoom": 6,
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "LineString"],
+                        ["==", ["get", "class"], "motorway"]
+                    ],
+                    "layout": {"line-cap": "round", "line-join": "round"},
+                    "paint": {
+                        "line-color": "hsla(0,0%,85%,0.53)",
+                        "line-width": [
+                        "interpolate",
+                        ["exponential", 1.4],
+                        ["zoom"],
+                        4,
+                        2,
+                        6,
+                        1.3
+                        ]
+                    }
+                    },
+                    {
+                    "id": "railway_transit",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation",
+                    "minzoom": 16,
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "LineString"],
+                        [
+                        "all",
+                        ["==", ["get", "class"], "transit"],
+                        ["match", ["get", "brunnel"], ["tunnel"], False, True]
+                        ]
+                    ],
+                    "layout": {"line-join": "round"},
+                    "paint": {"line-color": "#dddddd", "line-width": 3}
+                    },
+                    {
+                    "id": "railway_transit_dashline",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation",
+                    "minzoom": 16,
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "LineString"],
+                        [
+                        "all",
+                        ["==", ["get", "class"], "transit"],
+                        ["match", ["get", "brunnel"], ["tunnel"], False, True]
+                        ]
+                    ],
+                    "layout": {"line-join": "round"},
+                    "paint": {
+                        "line-color": "#fafafa",
+                        "line-dasharray": [3, 3],
+                        "line-width": 2
+                    }
+                    },
+                    {
+                    "id": "railway_service",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation",
+                    "minzoom": 16,
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "LineString"],
+                        ["all", ["==", ["get", "class"], "rail"], ["has", "service"]]
+                    ],
+                    "layout": {"line-join": "round"},
+                    "paint": {"line-color": "#dddddd", "line-width": 3}
+                    },
+                    {
+                    "id": "railway_service_dashline",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation",
+                    "minzoom": 16,
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "LineString"],
+                        ["==", ["get", "class"], "rail"],
+                        ["has", "service"]
+                    ],
+                    "layout": {"line-join": "round"},
+                    "paint": {
+                        "line-color": "#fafafa",
+                        "line-dasharray": [3, 3],
+                        "line-width": 2
+                    }
+                    },
+                    {
+                    "id": "railway",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation",
+                    "minzoom": 13,
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "LineString"],
+                        ["all", ["!", ["has", "service"]], ["==", ["get", "class"], "rail"]]
+                    ],
+                    "layout": {"line-join": "round"},
+                    "paint": {
+                        "line-color": "#dddddd",
+                        "line-width": [
+                        "interpolate",
+                        ["exponential", 1.3],
+                        ["zoom"],
+                        16,
+                        3,
+                        20,
+                        7
+                        ]
+                    }
+                    },
+                    {
+                    "id": "railway_dashline",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation",
+                    "minzoom": 13,
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "LineString"],
+                        ["all", ["!", ["has", "service"]], ["==", ["get", "class"], "rail"]]
+                    ],
+                    "layout": {"line-join": "round"},
+                    "paint": {
+                        "line-color": "#fafafa",
+                        "line-dasharray": [3, 3],
+                        "line-width": [
+                        "interpolate",
+                        ["exponential", 1.3],
+                        ["zoom"],
+                        16,
+                        2,
+                        20,
+                        6
+                        ]
+                    }
+                    },
+                    {
+                    "id": "highway_motorway_bridge_casing",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation",
+                    "minzoom": 6,
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "LineString"],
+                        [
+                        "all",
+                        ["==", ["get", "brunnel"], "bridge"],
+                        ["==", ["get", "class"], "motorway"]
+                        ]
+                    ],
+                    "layout": {"line-cap": "butt", "line-join": "miter"},
+                    "paint": {
+                        "line-color": "rgb(213, 213, 213)",
+                        "line-dasharray": [2, 0],
+                        "line-opacity": 1,
+                        "line-width": [
+                        "interpolate",
+                        ["exponential", 1.4],
+                        ["zoom"],
+                        5.8,
+                        0,
+                        6,
+                        5,
+                        20,
+                        45
+                        ]
+                    }
+                    },
+                    {
+                    "id": "highway_motorway_bridge_inner",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation",
+                    "minzoom": 6,
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "LineString"],
+                        [
+                        "all",
+                        ["==", ["get", "brunnel"], "bridge"],
+                        ["==", ["get", "class"], "motorway"]
+                        ]
+                    ],
+                    "layout": {"line-cap": "round", "line-join": "round"},
+                    "paint": {
+                        "line-color": [
+                        "interpolate",
+                        ["linear"],
+                        ["zoom"],
+                        5.8,
+                        "hsla(0,0%,85%,0.53)",
+                        6,
+                        "#fff"
+                        ],
+                        "line-width": [
+                        "interpolate",
+                        ["exponential", 1.4],
+                        ["zoom"],
+                        4,
+                        2,
+                        6,
+                        1.3,
+                        20,
+                        30
+                        ]
+                    }
+                    },
+                    {
+                    "id": "boundary_3",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "boundary",
+                    "minzoom": 1,
+                    "filter": [
+                        "all",
+                        [">=", ["get", "admin_level"], 3],
+                        ["<=", ["get", "admin_level"], 6],
+                        ["!=", ["get", "maritime"], 1],
+                        ["!=", ["get", "disputed"], 1],
+                        ["!", ["has", "claimed_by"]]
+                    ],
+                    "layout": {"visibility": "visible"},
+                    "paint": {
+                        "line-color": "hsl(0,0%,70%)",
+                        "line-dasharray": [1, 1],
+                        "line-width": ["interpolate", ["linear", 1], ["zoom"], 7, 1, 11, 2]
+                    }
+                    },
+                    {
+                    "id": "boundary_2",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "boundary",
+                    "filter": [
+                        "all",
+                        ["==", ["get", "admin_level"], 2],
+                        ["!=", ["get", "maritime"], 1],
+                        ["!=", ["get", "disputed"], 1],
+                        ["!", ["has", "claimed_by"]]
+                    ],
+                    "layout": {"line-cap": "round", "line-join": "round"},
+                    "paint": {
+                        "line-color": "hsl(0,0%,70%)",
+                        "line-opacity": ["interpolate", ["linear"], ["zoom"], 0, 0.4, 4, 1],
+                        "line-width": ["interpolate", ["linear"], ["zoom"], 3, 1, 5, 1.2, 12, 3]
+                    }
+                    },
+                    {
+                    "id": "boundary_disputed",
+                    "type": "line",
+                    "source": "openmaptiles",
+                    "source-layer": "boundary",
+                    "filter": [
+                        "all",
+                        ["!=", ["get", "maritime"], 1],
+                        ["==", ["get", "disputed"], 1]
+                    ],
+                    "paint": {
+                        "line-color": "hsl(0,0%,70%)",
+                        "line-dasharray": [1, 2],
+                        "line-width": ["interpolate", ["linear"], ["zoom"], 3, 1, 5, 1.2, 12, 3]
+                    }
+                    },
+                    {
+                    "id": "waterway_line_label",
+                    "type": "symbol",
+                    "source": "openmaptiles",
+                    "source-layer": "waterway",
+                    "minzoom": 10,
+                    "filter": ["==", ["geometry-type"], "LineString"],
+                    "layout": {
+                        "symbol-placement": "line",
+                        "symbol-spacing": 350,
+                        "text-field": [
+                        "case",
+                        ["has", "name:nonlatin"],
+                        ["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
+                        ["coalesce", ["get", "name_en"], ["get", "name"]]
+                        ],
+                        "text-font": ["Noto Sans Italic"],
+                        "text-letter-spacing": 0.2,
+                        "text-max-width": 5,
+                        "text-size": 14
+                    },
+                    "paint": {
+                        "text-color": "hsl(0,0%,66%)",
+                        "text-halo-color": "rgba(255,255,255,0.7)",
+                        "text-halo-width": 1.5
+                    }
+                    },
+                    {
+                    "id": "water_name_point_label",
+                    "type": "symbol",
+                    "source": "openmaptiles",
+                    "source-layer": "water_name",
+                    "filter": ["==", ["geometry-type"], "Point"],
+                    "layout": {
+                        "text-field": [
+                        "case",
+                        ["has", "name:nonlatin"],
+                        ["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
+                        ["coalesce", ["get", "name_en"], ["get", "name"]]
+                        ],
+                        "text-font": ["Noto Sans Italic"],
+                        "text-letter-spacing": 0.2,
+                        "text-max-width": 5,
+                        "text-size": ["interpolate", ["linear"], ["zoom"], 0, 10, 8, 14]
+                    },
+                    "paint": {
+                        "text-color": "#495e91",
+                        "text-halo-color": "rgba(255,255,255,0.7)",
+                        "text-halo-width": 1.5
+                    }
+                    },
+                    {
+                    "id": "water_name_line_label",
+                    "type": "symbol",
+                    "source": "openmaptiles",
+                    "source-layer": "water_name",
+                    "filter": ["==", ["geometry-type"], "LineString"],
+                    "layout": {
+                        "symbol-placement": "line",
+                        "symbol-spacing": 350,
+                        "text-field": [
+                        "case",
+                        ["has", "name:nonlatin"],
+                        ["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
+                        ["coalesce", ["get", "name_en"], ["get", "name"]]
+                        ],
+                        "text-font": ["Noto Sans Italic"],
+                        "text-letter-spacing": 0.2,
+                        "text-max-width": 5,
+                        "text-size": 14
+                    },
+                    "paint": {
+                        "text-color": "#495e91",
+                        "text-halo-color": "rgba(255,255,255,0.7)",
+                        "text-halo-width": 1.5
+                    }
+                    },
+                    {
+                    "id": "highway-name-path",
+                    "type": "symbol",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation_name",
+                    "minzoom": 15.5,
+                    "filter": ["==", ["get", "class"], "path"],
+                    "layout": {
+                        "symbol-placement": "line",
+                        "text-field": [
+                        "case",
+                        ["has", "name:nonlatin"],
+                        ["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
+                        ["coalesce", ["get", "name_en"], ["get", "name"]]
+                        ],
+                        "text-font": ["Noto Sans Regular"],
+                        "text-rotation-alignment": "map",
+                        "text-size": ["interpolate", ["linear"], ["zoom"], 13, 12, 14, 13]
+                    },
+                    "paint": {
+                        "text-color": "hsl(30,0%,62%)",
+                        "text-halo-color": "#f8f4f0",
+                        "text-halo-width": 0.5
+                    }
+                    },
+                    {
+                    "id": "highway-name-minor",
+                    "type": "symbol",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation_name",
+                    "minzoom": 15,
+                    "filter": [
+                        "all",
+                        ["==", ["geometry-type"], "LineString"],
+                        ["match", ["get", "class"], ["minor", "service", "track"], True, False]
+                    ],
+                    "layout": {
+                        "symbol-placement": "line",
+                        "text-field": [
+                        "case",
+                        ["has", "name:nonlatin"],
+                        ["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
+                        ["coalesce", ["get", "name_en"], ["get", "name"]]
+                        ],
+                        "text-font": ["Noto Sans Regular"],
+                        "text-rotation-alignment": "map",
+                        "text-size": ["interpolate", ["linear"], ["zoom"], 13, 12, 14, 13]
+                    },
+                    "paint": {
+                        "text-color": "#666",
+                        "text-halo-blur": 0.5,
+                        "text-halo-width": 1
+                    }
+                    },
+                    {
+                    "id": "highway-name-major",
+                    "type": "symbol",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation_name",
+                    "minzoom": 12.2,
+                    "filter": [
+                        "match",
+                        ["get", "class"],
+                        ["primary", "secondary", "tertiary", "trunk"],
+                        True,
+                        False
+                    ],
+                    "layout": {
+                        "symbol-placement": "line",
+                        "text-field": [
+                        "case",
+                        ["has", "name:nonlatin"],
+                        ["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
+                        ["coalesce", ["get", "name_en"], ["get", "name"]]
+                        ],
+                        "text-font": ["Noto Sans Regular"],
+                        "text-rotation-alignment": "map",
+                        "text-size": ["interpolate", ["linear"], ["zoom"], 13, 12, 14, 13]
+                    },
+                    "paint": {
+                        "text-color": "#666",
+                        "text-halo-blur": 0.5,
+                        "text-halo-width": 1
+                    }
+                    },
+                    {
+                    "id": "highway-shield-non-us",
+                    "type": "symbol",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation_name",
+                    "minzoom": 11,
+                    "filter": [
+                        "all",
+                        ["<=", ["get", "ref_length"], 6],
+                        ["==", ["geometry-type"], "LineString"],
+                        [
+                        "match",
+                        ["get", "network"],
+                        ["us-highway", "us-interstate", "us-state"],
+                        False,
+                        True
+                        ]
+                    ],
+                    "layout": {
+                        "icon-image": ["concat", "road_", ["get", "ref_length"]],
+                        "icon-rotation-alignment": "viewport",
+                        "icon-size": 1,
+                        "symbol-placement": ["step", ["zoom"], "point", 11, "line"],
+                        "symbol-spacing": 200,
+                        "text-field": ["to-string", ["get", "ref"]],
+                        "text-font": ["Noto Sans Regular"],
+                        "text-rotation-alignment": "viewport",
+                        "text-size": 10
+                    }
+                    },
+                    {
+                    "id": "highway-shield-us-interstate",
+                    "type": "symbol",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation_name",
+                    "minzoom": 11,
+                    "filter": [
+                        "all",
+                        ["<=", ["get", "ref_length"], 6],
+                        ["==", ["geometry-type"], "LineString"],
+                        ["match", ["get", "network"], ["us-interstate"], True, False]
+                    ],
+                    "layout": {
+                        "icon-image": [
+                        "concat",
+                        ["get", "network"],
+                        "_",
+                        ["get", "ref_length"]
+                        ],
+                        "icon-rotation-alignment": "viewport",
+                        "icon-size": 1,
+                        "symbol-placement": ["step", ["zoom"], "point", 7, "line", 8, "line"],
+                        "symbol-spacing": 200,
+                        "text-field": ["to-string", ["get", "ref"]],
+                        "text-font": ["Noto Sans Regular"],
+                        "text-rotation-alignment": "viewport",
+                        "text-size": 10
+                    }
+                    },
+                    {
+                    "id": "road_shield_us",
+                    "type": "symbol",
+                    "source": "openmaptiles",
+                    "source-layer": "transportation_name",
+                    "minzoom": 12,
+                    "filter": [
+                        "all",
+                        ["<=", ["get", "ref_length"], 6],
+                        ["==", ["geometry-type"], "LineString"],
+                        ["match", ["get", "network"], ["us-highway", "us-state"], True, False]
+                    ],
+                    "layout": {
+                        "icon-image": [
+                        "concat",
+                        ["get", "network"],
+                        "_",
+                        ["get", "ref_length"]
+                        ],
+                        "icon-rotation-alignment": "viewport",
+                        "icon-size": 1,
+                        "symbol-placement": ["step", ["zoom"], "point", 11, "line"],
+                        "symbol-spacing": 200,
+                        "text-field": ["to-string", ["get", "ref"]],
+                        "text-font": ["Noto Sans Regular"],
+                        "text-rotation-alignment": "viewport",
+                        "text-size": 10
+                    }
+                    },
+                    {
+                    "id": "airport",
+                    "type": "symbol",
+                    "source": "openmaptiles",
+                    "source-layer": "aerodrome_label",
+                    "minzoom": 11,
+                    "filter": ["all", ["has", "iata"]],
+                    "layout": {
+                        "icon-image": "airport_11",
+                        "icon-size": 1,
+                        "text-anchor": "top",
+                        "text-field": [
+                        "case",
+                        ["has", "name:nonlatin"],
+                        ["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
+                        ["coalesce", ["get", "name_en"], ["get", "name"]]
+                        ],
+                        "text-font": ["Noto Sans Regular"],
+                        "text-max-width": 9,
+                        "text-offset": [0, 0.6],
+                        "text-optional": True,
+                        "text-padding": 2,
+                        "text-size": 12
+                    },
+                    "paint": {
+                        "text-color": "#666",
+                        "text-halo-blur": 0.5,
+                        "text-halo-color": "#ffffff",
+                        "text-halo-width": 1
+                    }
+                    },
+                    {
+                    "id": "label_other",
+                    "type": "symbol",
+                    "source": "openmaptiles",
+                    "source-layer": "place",
+                    "minzoom": 8,
+                    "filter": [
+                        "match",
+                        ["get", "class"],
+                        ["city", "continent", "country", "state", "town", "village"],
+                        False,
+                        True
+                    ],
+                    "layout": {
+                        "text-field": [
+                        "case",
+                        ["has", "name:nonlatin"],
+                        ["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
+                        ["coalesce", ["get", "name_en"], ["get", "name"]]
+                        ],
+                        "text-font": ["Noto Sans Italic"],
+                        "text-letter-spacing": 0.1,
+                        "text-max-width": 9,
+                        "text-size": ["interpolate", ["linear"], ["zoom"], 8, 9, 12, 10],
+                        "text-transform": "uppercase"
+                    },
+                    "paint": {
+                        "text-color": "#333",
+                        "text-halo-blur": 1,
+                        "text-halo-color": "#fff",
+                        "text-halo-width": 1
+                    }
+                    },
+                    {
+                    "id": "label_village",
+                    "type": "symbol",
+                    "source": "openmaptiles",
+                    "source-layer": "place",
+                    "minzoom": 9,
+                    "filter": ["==", ["get", "class"], "village"],
+                    "layout": {
+                        "icon-allow-overlap": True,
+                        "icon-image": ["step", ["zoom"], "circle_11_black", 10, ""],
+                        "icon-optional": False,
+                        "icon-size": 0.2,
+                        "text-anchor": "bottom",
+                        "text-field": [
+                        "case",
+                        ["has", "name:nonlatin"],
+                        ["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
+                        ["coalesce", ["get", "name_en"], ["get", "name"]]
+                        ],
+                        "text-font": ["Noto Sans Regular"],
+                        "text-max-width": 8,
+                        "text-size": [
+                        "interpolate",
+                        ["exponential", 1.2],
+                        ["zoom"],
+                        7,
+                        10,
+                        11,
+                        12
+                        ]
+                    },
+                    "paint": {
+                        "text-color": "#000",
+                        "text-halo-blur": 1,
+                        "text-halo-color": "#fff",
+                        "text-halo-width": 1
+                    }
+                    },
+                    {
+                    "id": "label_town",
+                    "type": "symbol",
+                    "source": "openmaptiles",
+                    "source-layer": "place",
+                    "minzoom": 6,
+                    "filter": ["==", ["get", "class"], "town"],
+                    "layout": {
+                        "icon-allow-overlap": True,
+                        "icon-image": ["step", ["zoom"], "circle_11_black", 10, ""],
+                        "icon-optional": False,
+                        "icon-size": 0.2,
+                        "text-anchor": "bottom",
+                        "text-field": [
+                        "case",
+                        ["has", "name:nonlatin"],
+                        ["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
+                        ["coalesce", ["get", "name_en"], ["get", "name"]]
+                        ],
+                        "text-font": ["Noto Sans Regular"],
+                        "text-max-width": 8,
+                        "text-size": [
+                        "interpolate",
+                        ["exponential", 1.2],
+                        ["zoom"],
+                        7,
+                        12,
+                        11,
+                        14
+                        ]
+                    },
+                    "paint": {
+                        "text-color": "#aaa",
+                        "text-halo-blur": 1,
+                        "text-halo-color": "#fff",
+                        "text-halo-width": 1,
+                        "icon-color": "rgba(0, 0, 0, 1)"
+                    }
+                    },
+                    {
+                    "id": "label_state",
+                    "type": "symbol",
+                    "source": "openmaptiles",
+                    "source-layer": "place",
+                    "minzoom": 5,
+                    "maxzoom": 8,
+                    "filter": ["==", ["get", "class"], "state"],
+                    "layout": {
+                        "text-field": [
+                        "case",
+                        ["has", "name:nonlatin"],
+                        ["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
+                        ["coalesce", ["get", "name_en"], ["get", "name"]]
+                        ],
+                        "text-font": ["Noto Sans Italic"],
+                        "text-letter-spacing": 0.2,
+                        "text-max-width": 9,
+                        "text-size": ["interpolate", ["linear"], ["zoom"], 5, 10, 8, 14],
+                        "text-transform": "uppercase"
+                    },
+                    "paint": {
+                        "text-color": "#333",
+                        "text-halo-blur": 1,
+                        "text-halo-color": "#fff",
+                        "text-halo-width": 1
+                    }
+                    },
+                    {
+                    "id": "label_city",
+                    "type": "symbol",
+                    "source": "openmaptiles",
+                    "source-layer": "place",
+                    "minzoom": 3,
+                    "filter": [
+                        "all",
+                        ["==", ["get", "class"], "city"],
+                        ["!=", ["get", "capital"], 2]
+                    ],
+                    "layout": {
+                        "icon-allow-overlap": True,
+                        "icon-image": ["step", ["zoom"], "circle_11_black", 9, ""],
+                        "icon-optional": False,
+                        "icon-size": 0.4,
+                        "text-anchor": "bottom",
+                        "text-field": [
+                        "case",
+                        ["has", "name:nonlatin"],
+                        ["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
+                        ["coalesce", ["get", "name_en"], ["get", "name"]]
+                        ],
+                        "text-font": ["Noto Sans Regular"],
+                        "text-max-width": 8,
+                        "text-offset": [0, -0.1],
+                        "text-size": [
+                        "interpolate",
+                        ["exponential", 1.2],
+                        ["zoom"],
+                        4,
+                        11,
+                        7,
+                        13,
+                        11,
+                        18
+                        ]
+                    },
+                    "paint": {
+                        "text-color": "rgba(153, 153, 153, 1)",
+                        "text-halo-blur": 1,
+                        "text-halo-color": "#fff",
+                        "text-halo-width": 1
+                    }
+                    },
+                    {
+                    "id": "label_city_capital",
+                    "type": "symbol",
+                    "source": "openmaptiles",
+                    "source-layer": "place",
+                    "minzoom": 3,
+                    "filter": [
+                        "all",
+                        ["==", ["get", "class"], "city"],
+                        ["==", ["get", "capital"], 2]
+                    ],
+                    "layout": {
+                        "icon-allow-overlap": True,
+                        "icon-image": ["step", ["zoom"], "circle_11_black", 9, ""],
+                        "icon-optional": False,
+                        "icon-size": 0.5,
+                        "text-anchor": "bottom",
+                        "text-field": [
+                        "case",
+                        ["has", "name:nonlatin"],
+                        ["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
+                        ["coalesce", ["get", "name_en"], ["get", "name"]]
+                        ],
+                        "text-font": ["Noto Sans Bold"],
+                        "text-max-width": 8,
+                        "text-offset": [0, -0.2],
+                        "text-size": [
+                        "interpolate",
+                        ["exponential", 1.2],
+                        ["zoom"],
+                        4,
+                        12,
+                        7,
+                        14,
+                        11,
+                        20
+                        ]
+                    },
+                    "paint": {
+                        "text-color": "#000",
+                        "text-halo-blur": 1,
+                        "text-halo-color": "#fff",
+                        "text-halo-width": 1
+                    }
+                    },
+                    {
+                    "id": "label_country_3",
+                    "type": "symbol",
+                    "source": "openmaptiles",
+                    "source-layer": "place",
+                    "minzoom": 2,
+                    "maxzoom": 9,
+                    "filter": [
+                        "all",
+                        ["==", ["get", "class"], "country"],
+                        [">=", ["get", "rank"], 3]
+                    ],
+                    "layout": {
+                        "text-field": [
+                        "case",
+                        ["has", "name:nonlatin"],
+                        ["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
+                        ["coalesce", ["get", "name_en"], ["get", "name"]]
+                        ],
+                        "text-font": ["Noto Sans Bold"],
+                        "text-max-width": 6.25,
+                        "text-size": ["interpolate", ["linear"], ["zoom"], 3, 9, 7, 17]
+                    },
+                    "paint": {
+                        "text-color": "#000",
+                        "text-halo-blur": 1,
+                        "text-halo-color": "#fff",
+                        "text-halo-width": 1
+                    }
+                    },
+                    {
+                    "id": "label_country_2",
+                    "type": "symbol",
+                    "source": "openmaptiles",
+                    "source-layer": "place",
+                    "maxzoom": 9,
+                    "filter": [
+                        "all",
+                        ["==", ["get", "class"], "country"],
+                        ["==", ["get", "rank"], 2]
+                    ],
+                    "layout": {
+                        "text-field": [
+                        "case",
+                        ["has", "name:nonlatin"],
+                        ["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
+                        ["coalesce", ["get", "name_en"], ["get", "name"]]
+                        ],
+                        "text-font": ["Noto Sans Bold"],
+                        "text-max-width": 6.25,
+                        "text-size": ["interpolate", ["linear"], ["zoom"], 2, 9, 5, 17]
+                    },
+                    "paint": {
+                        "text-color": "#000",
+                        "text-halo-blur": 1,
+                        "text-halo-color": "#fff",
+                        "text-halo-width": 1
+                    }
+                    },
+                    {
+                    "id": "label_country_1",
+                    "type": "symbol",
+                    "source": "openmaptiles",
+                    "source-layer": "place",
+                    "maxzoom": 9,
+                    "filter": [
+                        "all",
+                        ["==", ["get", "class"], "country"],
+                        ["==", ["get", "rank"], 1]
+                    ],
+                    "layout": {
+                        "text-field": [
+                        "case",
+                        ["has", "name:nonlatin"],
+                        ["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
+                        ["coalesce", ["get", "name_en"], ["get", "name"]]
+                        ],
+                        "text-font": ["Noto Sans Bold"],
+                        "text-max-width": 6.25,
+                        "text-size": ["interpolate", ["linear"], ["zoom"], 1, 9, 4, 17]
+                    },
+                    "paint": {
+                        "text-color": "#000",
+                        "text-halo-blur": 1,
+                        "text-halo-color": "#fff",
+                        "text-halo-width": 1
+                    }
+                    }
+                ],
+            },
+            "arches_metadata": {"addtomap": True, "icon": "fa fa-globe", "isoverlay": False},
+        }
+
+        reference_collections = {
+            "maplayerid": uuid.UUID("803829fe-b437-40b2-94a4-8ae10fa25b10"),
+            "sortorder": 1,
+            "style": {
+                "name": "Reference Collections",
+                "sources": {
+                    "referencecollections": {
+                        "type": "vector",
+                        "tiles": ["/api-reference-collection-mvt/{z}/{x}/{y}.pbf"],
+                        "minzoom": 1,
+                    }
+                },
+                "layers": [
+                    {
+                        "id": "referencecollections-line",
+                        "type": "line",
+                        "paint": {
+                            "line-color": "#00f",
+                            "line-width": 3
+                        },
+                        "layout": {
+                            "line-cap": "round",
+                            "line-join": "round"
+                        },
+                        "source": "referencecollections",
+                        "source-layer": "referencecollections"
+                    },
+                    {
+                        "id": "referencecollections-polygon-line",
+                        "type": "line",
+                        "paint": {
+                            "line-color": "#00f",
+                            "line-width": 3
+                        },
+                        "filter": [
+                            "==",
+                            "$type",
+                            "Polygon"
+                        ],
+                        "layout": {
+                            "line-cap": "round",
+                            "line-join": "round"
+                        },
+                        "source": "referencecollections",
+                        "source-layer": "referencecollections"
+                    },
+                    {
+                        "id": "referencecollections-fill",
+                        "type": "fill",
+                        "paint": {
+                            "fill-color": "#00f",
+                            "fill-opacity": 0.1,
+                            "fill-outline-color": "#0ff"
+                        },
+                        "filter": [
+                            "==",
+                            "$type",
+                            "Polygon"
+                        ],
+                        "source": "referencecollections",
+                        "source-layer": "referencecollections"
+                    },
+                    {
+                        "id": "referencecollections-labels",
+                        "type": "symbol",
+                        "paint": {
+                            "text-color": "#33d",
+                            "text-halo-color": "#fff",
+                            "text-halo-width": 2.5
+                        },
+                        "layout": {
+                            "text-font": [
+                                "Open Sans Semibold",
+                                "Arial Unicode MS Bold"
+                            ],
+                            "text-size": 18,
+                            "text-field": [
+                                "get",
+                                "quad_name"
+                            ],
+                            "text-justify": "auto",
+                            "text-radial-offset": 0.5,
+                            "text-variable-anchor": [
+                                "top",
+                                "bottom",
+                                "left",
+                                "right"
+                            ]
+                        },
+                        "source": "referencecollections",
+                        "minzoom": 9,
+                        "source-layer": "referencecollections"
+                    }
+                ],
+            },
+            "arches_metadata": {"addtomap": True, "icon": "fa fa-globe", "isoverlay": True},
+        }
+
+        layer_configs = (ofm_positron_light, reference_collections)
+
+        for config in layer_configs:
+            try:
+                config["style"] = json.loads(config["style"])
+            except:
+                pass
+            layer_name = config["style"]["name"]
+            for layer in config["style"]["layers"]:
+                if "source" in layer:
+                    layer["source"] = layer["source"]
+            for source_name, source_dict in config["style"]["sources"].items():
+                MapSource.objects.get_or_create(name=source_name, source=source_dict)
+
+            map_layer = MapLayer(
+                maplayerid=config["maplayerid"],
+                name=layer_name,
+                sortorder=config["sortorder"],
+                layerdefinitions=config["style"]["layers"],
+                **config["arches_metadata"],
+            )
+            map_layer.save()
+
+    def remove_map_layers(apps, schema_editor):
+        MapSource = apps.get_model("models", "MapSource")
+        MapLayer = apps.get_model("models", "MapLayer")
+        layerids = (
+            "803829fe-b437-40b2-94a4-8ae10fa25b10",
+        )
+        for layerid in layerids:
+            mapbox_layer = MapLayer.objects.get(maplayerid=layerid)
+            all_sources = [i.get("source") for i in mapbox_layer.layerdefinitions]
+            sources = {i for i in all_sources if i}
+            for source in sources:
+                src = MapSource.objects.get(name=source)
+                src.delete()
+            mapbox_layer.delete()
+
+
+    operations = [
+        migrations.RunPython(add_map_layers, remove_map_layers),
+    ]

--- a/afrc/src/afrc/Search/SearchPage.vue
+++ b/afrc/src/afrc/Search/SearchPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref, watch } from "vue";
+import { onMounted, ref, watch, provide } from "vue";
 import type { Ref } from "vue";
 import { useGettext } from "vue3-gettext";
 
@@ -34,6 +34,8 @@ const resultsSelected: Ref<string[]> = ref([]);
 const dataLoaded = ref(false);
 const toast = useToast();
 const { $gettext } = useGettext();
+
+provide("resultsSelected", resultsSelected);
 
 watch(queryString, () => {
     doQuery();
@@ -225,7 +227,6 @@ onMounted(async () =>{
                 style="width: 100%; height: 100%"
             >
                 <InteractiveMap
-                    v-model="resultsSelected"
                     :basemaps="basemaps"
                     :overlays="overlays"
                     :sources="sources"

--- a/afrc/src/afrc/Search/SearchPage.vue
+++ b/afrc/src/afrc/Search/SearchPage.vue
@@ -150,7 +150,13 @@ async function fetchSystemMapData() {
         );
 
         layers.filter((layer: MapLayer) => !layer.isoverlay).forEach((layer: MapLayer) => {
-            basemaps.value.push({name: layer.name, active: layer.addtomap, value: layer.name, id: layer.name});
+            basemaps.value.push({
+                name: layer.name, 
+                active: layer.addtomap, 
+                value: layer.name, 
+                id: layer.name,
+                url: "https://tiles.openfreemap.org/styles/positron"
+            });
         });
 
         sources.value = mapData.map_sources;

--- a/afrc/src/afrc/Search/SearchPage.vue
+++ b/afrc/src/afrc/Search/SearchPage.vue
@@ -30,6 +30,7 @@ const showMap = ref(false);
 const basemaps: Ref<Basemap[]> = ref([]);
 const overlays: Ref<MapLayer[]> = ref([]);
 const sources: Ref<MapSource[]> = ref([]);
+const resultsSelected: Ref<string[]> = ref([]);
 const dataLoaded = ref(false);
 const toast = useToast();
 const { $gettext } = useGettext();
@@ -97,6 +98,7 @@ const doQuery = function () {
             console.log(data);
             searchResults.value = data.results.hits.hits;
             resultsCount.value = data.total_results;
+            resultsSelected.value = [];
         });
 
     // self.updateRequest = $.ajax({
@@ -223,6 +225,7 @@ onMounted(async () =>{
                 style="width: 100%; height: 100%"
             >
                 <InteractiveMap
+                    v-model="resultsSelected"
                     :basemaps="basemaps"
                     :overlays="overlays"
                     :sources="sources"

--- a/afrc/src/afrc/Search/SearchPage.vue
+++ b/afrc/src/afrc/Search/SearchPage.vue
@@ -230,6 +230,7 @@ onMounted(async () =>{
                     :basemaps="basemaps"
                     :overlays="overlays"
                     :sources="sources"
+                    :include-drawer="false"
                 />
             </div>
 

--- a/afrc/src/afrc/Search/components/InteractiveMap/InteractiveMap.vue
+++ b/afrc/src/afrc/Search/components/InteractiveMap/InteractiveMap.vue
@@ -35,6 +35,7 @@ const props = defineProps<{
     overlays: MapLayer[];
     basemaps: Basemap[];
     sources: MapSource[];
+    includeDrawer: boolean;
 }>();
 
 const map: Ref<Map | null> = ref(null);
@@ -132,7 +133,7 @@ function updateSelectedDrawnFeature(feature: Feature) {
             @drawn-feature-selected="updateSelectedDrawnFeature"
         />
         <InteractionsDrawer
-            v-if="map"
+            v-if="map && includeDrawer"
             :map="map"
             :settings="settings"
             :items="mapInteractionItems"

--- a/afrc/src/afrc/Search/components/InteractiveMap/InteractiveMap.vue
+++ b/afrc/src/afrc/Search/components/InteractiveMap/InteractiveMap.vue
@@ -71,7 +71,6 @@ provide("overlays", props.overlays);
 provide("basemaps", props.basemaps);
 provide("selectedDrawnFeature", selectedDrawnFeature);
 
-let resultsSelected = defineModel();
 
 watch(
     () => props.basemaps,
@@ -82,14 +81,6 @@ watch(
                 break;
             }
         }
-    },
-    { deep: true, immediate: true },
-);
-
-watch(
-    () => resultsSelected,
-    (x) => {
-        console.log("resultsSelected", x);
     },
     { deep: true, immediate: true },
 );
@@ -123,7 +114,6 @@ function updateSelectedDrawnFeature(feature: Feature) {
         style="display: flex; height: 100%; width: 100%"
     >
         <MapComponent
-            v-model="resultsSelected"
             :settings="settings"
             :basemap="basemap"
             :overlays="overlays"

--- a/afrc/src/afrc/Search/components/InteractiveMap/InteractiveMap.vue
+++ b/afrc/src/afrc/Search/components/InteractiveMap/InteractiveMap.vue
@@ -90,7 +90,6 @@ onMounted(async () => {
 
 async function fetchSystemSettings() {
     try {
-        console.log("Fetching settings");
         settings.value = await fetchSettings();
     } catch (error) {
         toast.add({

--- a/afrc/src/afrc/Search/components/InteractiveMap/InteractiveMap.vue
+++ b/afrc/src/afrc/Search/components/InteractiveMap/InteractiveMap.vue
@@ -71,6 +71,8 @@ provide("overlays", props.overlays);
 provide("basemaps", props.basemaps);
 provide("selectedDrawnFeature", selectedDrawnFeature);
 
+let resultsSelected = defineModel();
+
 watch(
     () => props.basemaps,
     (updatedBasemaps) => {
@@ -80,6 +82,14 @@ watch(
                 break;
             }
         }
+    },
+    { deep: true, immediate: true },
+);
+
+watch(
+    () => resultsSelected,
+    (x) => {
+        console.log("resultsSelected", x);
     },
     { deep: true, immediate: true },
 );
@@ -113,6 +123,7 @@ function updateSelectedDrawnFeature(feature: Feature) {
         style="display: flex; height: 100%; width: 100%"
     >
         <MapComponent
+            v-model="resultsSelected"
             :settings="settings"
             :basemap="basemap"
             :overlays="overlays"

--- a/afrc/src/afrc/Search/components/InteractiveMap/InteractiveMap.vue
+++ b/afrc/src/afrc/Search/components/InteractiveMap/InteractiveMap.vue
@@ -66,7 +66,7 @@ const basemap: Ref<Basemap | null> = ref(null);
 const selectedDrawnFeature: Ref<Feature | null> = ref(null);
 
 const emits = defineEmits(["drawnFeatureSelected", "drawnFeaturesUpdated"]);
-console.log(props);
+
 provide("overlays", props.overlays);
 provide("basemaps", props.basemaps);
 provide("selectedDrawnFeature", selectedDrawnFeature);

--- a/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
+++ b/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
@@ -250,7 +250,7 @@ function createMap() {
     map.value = new maplibregl.Map({
         container: mapContainer.value!,
         zoom: 10,
-        center: [-118.805, 34.027],
+        center: [-122.105, 37.027],
     });
 
     emits("mapInitialized", map.value);
@@ -260,7 +260,7 @@ function updateBasemap(basemap: Basemap) {
     console.log(basemap);
     console.log(overlays);
     map.value!.setStyle(
-        'https://demotiles.maplibre.org/style.json',
+        basemap.url,
     );
 
     map.value!.once(IDLE, () => {
@@ -334,8 +334,9 @@ function addOverlayToMap(overlay: MapLayer) {
                 );
             }
         }
-
+        console.log('adding layer object');
         if (!map.value!.getLayer(layerDefinition.id)) {
+            console.log('adding layer object2');
             map.value!.addLayer(layerDefinition as AddLayerObject);
         }
     });

--- a/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
+++ b/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
@@ -127,6 +127,13 @@ watch(
 );
 
 watch(
+    () => resultsSelected,
+    (selected) => {
+        updateFeatureSelection(selected);
+    }, {deep: true}
+);
+
+watch(
     () => drawnFeaturesBuffer,
     () => {
         updateDrawnFeatures();
@@ -186,6 +193,28 @@ async function fitBoundsOfFeatures(features: FeatureCollection) {
         padding: { top: 50, right: 100, bottom: 50, left: 50 },
     });
 }
+
+function updateFeatureSelection(selected: Ref<string[]>) {
+    const layers = []
+    overlays.forEach((overlay) => {
+        layers.push(...overlay.layerdefinitions.map(
+            (layerDefinition) => layerDefinition.id,
+        ));
+    });
+    const features = map.value!.queryRenderedFeatures({layers:layers});
+    features.forEach(feature => {
+        const featureSelected = selected.value.includes(feature.properties?.resourceinstanceid);
+        map.value.setFeatureState(
+            {
+                source: "referencecollections",
+                sourceLayer: "referencecollections",
+                id: feature.id,
+            },
+            { selected: featureSelected }
+        );
+    });
+}
+
 
 function addBufferLayer() {
     map.value!.addSource(BUFFER_LAYER_ID, {

--- a/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
+++ b/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
@@ -257,8 +257,6 @@ function createMap() {
 }
 
 function updateBasemap(basemap: Basemap) {
-    console.log(basemap);
-    console.log(overlays);
     map.value!.setStyle(
         basemap.url,
     );
@@ -334,9 +332,7 @@ function addOverlayToMap(overlay: MapLayer) {
                 );
             }
         }
-        console.log('adding layer object');
         if (!map.value!.getLayer(layerDefinition.id)) {
-            console.log('adding layer object2');
             map.value!.addLayer(layerDefinition as AddLayerObject);
         }
     });

--- a/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
+++ b/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
@@ -88,7 +88,7 @@ const {
     drawnFeaturesBuffer,
 } = props;
 
-let resultsSelected = inject("resultsSelected");
+let resultsSelected = inject("resultsSelected") as Ref<string[]>;
 
 const emits = defineEmits([
     "mapInitialized",
@@ -129,7 +129,9 @@ watch(
 watch(
     () => resultsSelected,
     (selected) => {
-        updateFeatureSelection(selected);
+        if (selected) {
+            updateFeatureSelection(selected as Ref<string[]>);
+        }
     }, {deep: true}
 );
 
@@ -204,7 +206,7 @@ function updateFeatureSelection(selected: Ref<string[]>) {
     const features = map.value!.queryRenderedFeatures({layers:layers});
     features.forEach(feature => {
         const featureSelected = selected.value.includes(feature.properties?.resourceinstanceid);
-        map.value.setFeatureState(
+        map.value!.setFeatureState(
             {
                 source: "referencecollections",
                 sourceLayer: "referencecollections",

--- a/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
+++ b/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref, useTemplateRef, watch } from "vue";
+import { onMounted, ref, useTemplateRef, watch, inject } from "vue";
 
 import MapboxDraw from "@mapbox/mapbox-gl-draw";
 import maplibregl from "maplibre-gl";
@@ -88,7 +88,7 @@ const {
     drawnFeaturesBuffer,
 } = props;
 
-let resultsSelected = defineModel();
+let resultsSelected = inject("resultsSelected");
 
 const emits = defineEmits([
     "mapInitialized",

--- a/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
+++ b/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
@@ -195,7 +195,7 @@ async function fitBoundsOfFeatures(features: FeatureCollection) {
 }
 
 function updateFeatureSelection(selected: Ref<string[]>) {
-    const layers = []
+    const layers: Array<string> = [];
     overlays.forEach((overlay) => {
         layers.push(...overlay.layerdefinitions.map(
             (layerDefinition) => layerDefinition.id,

--- a/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
+++ b/afrc/src/afrc/Search/components/InteractiveMap/components/MapComponent.vue
@@ -88,6 +88,8 @@ const {
     drawnFeaturesBuffer,
 } = props;
 
+let resultsSelected = defineModel();
+
 const emits = defineEmits([
     "mapInitialized",
     "drawnFeatureSelected",
@@ -337,9 +339,7 @@ function addOverlayToMap(overlay: MapLayer) {
         }
     });
 
-    if (
-        overlay.maplayerid === "8914d88e-ac00-4140-a7d8-81893099b0ad" // Cultural Resource - Primary
-    ) {
+    if (overlay.maplayerid && resultsSelected) {
         resourceOverlaysClickHandlers[overlay.maplayerid] = function (
             e: MapMouseEvent,
         ) {
@@ -352,6 +352,11 @@ function addOverlayToMap(overlay: MapLayer) {
                 popupContainerRerenderKey.value += 1;
                 clickedCoordinates.value = [e.lngLat.lng, e.lngLat.lat];
                 clickedFeatures.value = features;
+                resultsSelected.value = [];
+                const uniqueResourceIds = new Set(features.map((feature) => feature.properties?.resourceinstanceid as string));
+                resultsSelected.value = Array.from(uniqueResourceIds);
+            } else {
+                resultsSelected.value = [];
             }
         };
 

--- a/afrc/src/afrc/Search/components/SearchResultItem.vue
+++ b/afrc/src/afrc/Search/components/SearchResultItem.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import Button from "primevue/button";
+import { inject } from "vue";
+
+let resultsSelected = inject("resultsSelected");
 
 const props = defineProps({
     searchResult: {

--- a/afrc/src/afrc/Search/components/SearchResultItem.vue
+++ b/afrc/src/afrc/Search/components/SearchResultItem.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import Button from "primevue/button";
 import { inject } from "vue";
+import type { Ref } from "vue";
 
-let resultsSelected = inject("resultsSelected");
+const resultsSelected = inject("resultsSelected") as Ref<string[]>;
 
 const props = defineProps({
     searchResult: {
@@ -11,20 +12,25 @@ const props = defineProps({
     },
 });
 
-function selectResult(resourceid) {
+function selectResult(resourceid: string) {
     resultsSelected.value = [resourceid];
 }
 
-function clearResult(e) {
+function clearResult() {
     resultsSelected.value = [];
 }
 
 </script>
 
 <template>
-    <section class="result" :class="{ hovered: resultsSelected.includes(searchResult._source.resourceinstanceid)}"
-            @mouseenter="selectResult(searchResult._source.resourceinstanceid)" 
-            @mouseleave="clearResult">
+    <section 
+        class="result" 
+        :class="{ 
+            hovered: resultsSelected.includes(searchResult._source.resourceinstanceid)
+        }"
+        @mouseenter="selectResult(searchResult._source.resourceinstanceid)" 
+        @mouseleave="clearResult"
+    >
         <div class="image-placeholder">
             <img src="https://picsum.photos/160" />
         </div>

--- a/afrc/src/afrc/Search/components/SearchResultItem.vue
+++ b/afrc/src/afrc/Search/components/SearchResultItem.vue
@@ -10,10 +10,21 @@ const props = defineProps({
         required: true,
     },
 });
+
+function selectResult(resourceid) {
+    resultsSelected.value = [resourceid];
+}
+
+function clearResult(e) {
+    resultsSelected.value = [];
+}
+
 </script>
 
 <template>
-    <section class="result">
+    <section class="result" :class="{ hovered: resultsSelected.includes(searchResult._source.resourceinstanceid)}"
+            @mouseenter="selectResult(searchResult._source.resourceinstanceid)" 
+            @mouseleave="clearResult">
         <div class="image-placeholder">
             <img src="https://picsum.photos/160" />
         </div>
@@ -46,6 +57,10 @@ const props = defineProps({
     border: 1px solid #ddd;
     display: flex;
     flex-direction: row;
+}
+.result.hovered {
+    background-color: rgb(239 245 252);
+    border: 1px solid rgb(139 145 252);
 }
 .result .result-content {
     height: 10rem;

--- a/afrc/src/afrc/Search/types.ts
+++ b/afrc/src/afrc/Search/types.ts
@@ -20,6 +20,7 @@ export interface Basemap {
     name: string;
     value: string;
     active: boolean;
+    url: string;
 }
 export interface MapLayer {
     activated?: boolean;

--- a/afrc/urls.py
+++ b/afrc/urls.py
@@ -1,9 +1,9 @@
 from django.conf import settings
 from django.conf.urls.static import static
 from django.conf.urls.i18n import i18n_patterns
-from django.urls import include, path
+from django.urls import include, path, re_path
 from afrc.views.settings_api import SettingsAPI
-from afrc.views.map_api import MapDataAPI, FeatureBufferAPI, GeoJSONBoundsAPI
+from afrc.views.map_api import MapDataAPI, FeatureBufferAPI, GeoJSONBoundsAPI, ReferenceCollectionMVT
 
 urlpatterns = [
     # project-level urls
@@ -11,6 +11,9 @@ urlpatterns = [
     path("api-map-data", MapDataAPI.as_view(), name="api-map-data"),
     path("api-feature-buffer", FeatureBufferAPI.as_view(), name="api-feature-buffer"),
     path("api-geojson-bounds", GeoJSONBoundsAPI.as_view(), name="api-geojson-bounds"),
+    re_path(r"^api-reference-collection-mvt/(?P<zoom>[0-9]+|\{z\})/(?P<x>[0-9]+|\{x\})/(?P<y>[0-9]+|\{y\}).pbf$",
+        ReferenceCollectionMVT.as_view(),
+        name="api-reference-collection-mvt"),
 ]
 
 # Ensure Arches core urls are superseded by project-level urls


### PR DESCRIPTION
Adds an overlay for reference collections. For dev purposes it's rendering all geometries so that it's not graph dependent. 

Also adds a url property for the basemap type so that the basemap url does not need to be hardcoded in the map component.