### PR TITLE
Lift datatype restriction in descriptor function

### DIFF
--- a/arches_rascolls/media/js/views/components/functions/multicard-resource-descriptor.js
+++ b/arches_rascolls/media/js/views/components/functions/multicard-resource-descriptor.js
@@ -50,7 +50,9 @@ ko.components.register('views/components/functions/multicard-resource-descriptor
         this.groupedNodesForSelect2 = [];
         sortedCards.forEach(card => {
             const stringNodes = this.graph.nodes.filter(
-                node => (node.datatype === 'string' || node.datatype === 'non-localized-string') && node.nodegroup_id === card.nodegroup_id
+                (node) => {
+                    return (node.nodegroup_id === card.nodegroup_id);
+                }
             );
 
             if (stringNodes.length) {


### PR DESCRIPTION
Removes restriction on multicard descriptor to allow for datatypes other than string/non-localized string