### PR TITLE
Use pypi dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "arches_rascolls"
+name = "arches-rascolls"
 readme = "README.md"
 authors = []
 license = {text = "GNU AGPL3"}


### PR DESCRIPTION
1. Replaces github branch dependencies with pypi dependencies. 
2. Changes upper bound for arches to version to anything below v9. 
3. Changes project name to reflect package name in accordance with PEP recommendations