### PR TITLE
Redirect to modular report if user visits resource editor

### DIFF
--- a/arches_rascolls/urls.py
+++ b/arches_rascolls/urls.py
@@ -2,6 +2,10 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.conf.urls.i18n import i18n_patterns
 from django.urls import include, path, re_path
+from arches_rascolls.views.resource import (
+    ModularReportAddResourceView,
+    ModularReportUpdateResourceView,
+)
 from arches_rascolls.views.file_api import FileAPI
 from arches_rascolls.views.settings_api import SettingsAPI
 from arches_rascolls.views.search_api import SearchAPI
@@ -53,6 +57,16 @@ urlpatterns = [
         name="api-reference-collection-search-mvt",
     ),
     re_path(r"^rascoll-search$", RascollSearchView.as_view(), name="rascoll-search"),
+    path(
+        "resource/<uuid:resourceid>",
+        ModularReportUpdateResourceView.as_view(),
+        name="resource_editor",
+    ),
+    path(
+        "add-resource/<uuid:graphid>",
+        ModularReportAddResourceView.as_view(),
+        name="add_resource",
+    ),
 ]
 
 urlpatterns.append(path("", include("arches_modular_reports.urls")))

--- a/arches_rascolls/views/resource.py
+++ b/arches_rascolls/views/resource.py
@@ -1,0 +1,20 @@
+import uuid
+
+from django.views import View
+from django.shortcuts import redirect
+
+from arches.app.models import models
+
+
+class ModularReportAddResourceView(View):
+    def get(self, request, graphid):
+        resourceid = str(uuid.uuid4())
+        models.ResourceInstance.objects.create(
+            graph_id=graphid, resourceinstanceid=resourceid
+        )
+        return redirect("resource_report", resourceid=resourceid)
+
+
+class ModularReportUpdateResourceView(View):
+    def get(self, request, resourceid):
+        return redirect("resource_report", resourceid=resourceid)


### PR DESCRIPTION
If a user visits the 'add-resource' endpoint, a new resource is created and they are redirected to a report. If a user visits the editor to update an existing resource (resource/[resourceid]), they are simply redirected to the report.