### PR TITLE
Pin django to non-pre version

### DIFF
--- a/arches_rascolls/management/commands/load_rascolls_data.py
+++ b/arches_rascolls/management/commands/load_rascolls_data.py
@@ -34,6 +34,9 @@ class Command(BaseCommand):
         if not data_dir.is_dir():
             raise CommandError(f"'{data_dir}' is not a directory.")
 
+        self.stdout.write("\n>>> report_configs load")
+        call_command("report_configs", "load")
+
         xlsx_files = sorted(data_dir.glob("*.xlsx"))
         if not xlsx_files:
             raise CommandError(f"No *.xlsx files found in '{data_dir}'.")
@@ -48,8 +51,5 @@ class Command(BaseCommand):
 
         self.stdout.write("\n>>> arches_search reindex_database -mp -mxp 5")
         call_command("arches_search", "reindex_database", "-mp", "-mxp", "5")
-
-        self.stdout.write("\n>>> report_configs load")
-        call_command("report_configs", "load")
 
         self.stdout.write(self.style.SUCCESS("\nDone."))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 requires-python = ">=3.12"
 dependencies = [
     "arches>=8.2.0a8,<9.0.0",
+    "Django==6.0.7",
     "django_csp==3.8",
     "arches_modular_reports>=2.0.0",
     "arches_search>=0.1.0a11",


### PR DESCRIPTION
Temporarily pins Django to version 6.0.7. This prevents the release candidate (6.1.0rc) from installing which has a conflict with the Django 6.1.0rc.